### PR TITLE
Enable direct touch planting on touch screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,23 +304,18 @@
   // Touch controls
   const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
   if (isTouch) {
-    for (const el of document.querySelectorAll('.touch-controls')) {
-      el.style.display = 'flex';
-    }
-  }
-  for (const btn of document.querySelectorAll('[data-key]')) {
-    btn.addEventListener('pointerdown', e => {
-      keys.add(btn.dataset.key);
-      e.preventDefault();
-      btn.setPointerCapture(e.pointerId);
+    cv.addEventListener('pointerdown', e => {
+      const rect = cv.getBoundingClientRect();
+      const x = (e.clientX - rect.left) * cv.width / rect.width;
+      const y = (e.clientY - rect.top) * cv.height / rect.height;
+      const plot = state.plots.find(pl => inside(x, y, 0, 0, pl.x, pl.y, pl.w, pl.h));
+      if (!plot) return;
+      const p = playerByName(plot.owner);
+      const oldX = p.x, oldY = p.y;
+      p.x = plot.x; p.y = plot.y;
+      playerAction(p, plot.owner);
+      p.x = oldX; p.y = oldY;
     });
-    btn.addEventListener('pointerup', e => {
-      keys.delete(btn.dataset.key);
-      btn.releasePointerCapture(e.pointerId);
-    });
-    const clear = () => { keys.delete(btn.dataset.key); };
-    btn.addEventListener('pointerleave', clear);
-    btn.addEventListener('pointercancel', clear);
   }
 
   function movePlayer(p, up, left, down, right) {
@@ -564,8 +559,10 @@
     }
 
     // Players
-    drawPlayer(state.p1, '#2563eb');
-    drawPlayer(state.p2, '#e11d48');
+    if (!isTouch) {
+      drawPlayer(state.p1, '#2563eb');
+      drawPlayer(state.p2, '#e11d48');
+    }
 
     // HUD
     p1moneyEl.textContent = `P1 Money: ¢${state.p1.money}`;
@@ -649,24 +646,26 @@
 
   // ---------- MAIN LOOP ----------
   function tick() {
-    movePlayer(state.p1, 'KeyW','KeyA','KeyS','KeyD');
-    movePlayer(state.p2, 'ArrowUp','ArrowLeft','ArrowDown','ArrowRight');
+    if (!isTouch) {
+      movePlayer(state.p1, 'KeyW','KeyA','KeyS','KeyD');
+      movePlayer(state.p2, 'ArrowUp','ArrowLeft','ArrowDown','ArrowRight');
 
-    if (justPressed('KeyE')) playerAction(state.p1, 'P1');
-    if (justPressed('Slash')) playerAction(state.p2, 'P2');
+      if (justPressed('KeyE')) playerAction(state.p1, 'P1');
+      if (justPressed('Slash')) playerAction(state.p2, 'P2');
 
-    if (justPressed('KeyQ')) state.p1.selected = (state.p1.selected==='candy'?'carrot':'candy');
-    if (justPressed('Period')) state.p2.selected = (state.p2.selected==='candy'?'carrot':'candy');
+      if (justPressed('KeyQ')) state.p1.selected = (state.p1.selected==='candy'?'carrot':'candy');
+      if (justPressed('Period')) state.p2.selected = (state.p2.selected==='candy'?'carrot':'candy');
 
-    if (justPressed('KeyH')) eventsPanel.classList.toggle('open');
+      if (justPressed('KeyH')) eventsPanel.classList.toggle('open');
 
-    if (!inside(state.p1.x,state.p1.y,state.p1.w,state.p1.h, VENDORS.shop.x,VENDORS.shop.y,VENDORS.shop.w,VENDORS.shop.h) &&
-        !inside(state.p2.x,state.p2.y,state.p2.w,state.p2.h, VENDORS.shop.x,VENDORS.shop.y,VENDORS.shop.w,VENDORS.shop.h)) {
-      state.shopOpen = false;
-    }
-    if (!inside(state.p1.x,state.p1.y,state.p1.w,state.p1.h, VENDORS.sell.x,VENDORS.sell.y,VENDORS.sell.w,VENDORS.sell.h) &&
-        !inside(state.p2.x,state.p2.y,state.p2.w,state.p2.h, VENDORS.sell.x,VENDORS.sell.y,VENDORS.sell.w,VENDORS.sell.h)) {
-      state.sellOpen = false;
+      if (!inside(state.p1.x,state.p1.y,state.p1.w,state.p1.h, VENDORS.shop.x,VENDORS.shop.y,VENDORS.shop.w,VENDORS.shop.h) &&
+          !inside(state.p2.x,state.p2.y,state.p2.w,state.p2.h, VENDORS.shop.x,VENDORS.shop.y,VENDORS.shop.w,VENDORS.shop.h)) {
+        state.shopOpen = false;
+      }
+      if (!inside(state.p1.x,state.p1.y,state.p1.w,state.p1.h, VENDORS.sell.x,VENDORS.sell.y,VENDORS.sell.w,VENDORS.sell.h) &&
+          !inside(state.p2.x,state.p2.y,state.p2.w,state.p2.h, VENDORS.sell.x,VENDORS.sell.y,VENDORS.sell.w,VENDORS.sell.h)) {
+        state.sellOpen = false;
+      }
     }
 
     maybeStartWorldEvent();


### PR DESCRIPTION
## Summary
- Add touch detection to allow planting directly via screen taps
- Hide character avatars and skip keyboard logic when touch is enabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbfc4fe8c83239fd3068b19bedb67