### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Garden Harvster
+
+A simple 2‑player cooperative browser game. The game is contained in a single `index.html` file.
+
+## GitHub Pages
+
+The repository includes a GitHub Actions workflow that publishes the contents of the repository to GitHub Pages whenever changes are pushed to `main`. After enabling GitHub Pages in the repository settings, the game will be available at `https://<username>.github.io/GardenHarvster/`.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy the site to GitHub Pages when changes land on `main`
- include `.nojekyll` to serve static files without Jekyll processing
- document site and deployment behavior in README

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc1baa48c8323b165fc83e0adf022