### PR TITLE
Add basic network co-op with local override

### DIFF
--- a/game.js
+++ b/game.js
@@ -129,11 +129,30 @@
     buyCarrotP2,
   });
 
-  addP2Btn.onclick = () => {
+  function enableP2() {
     state.p2Active = true;
     p2Elems.forEach(el => el.classList.remove('p2'));
     addP2Btn.style.display = 'none';
+  }
+
+  addP2Btn.onclick = () => {
+    if (net) net.disconnect();
+    enableP2();
   };
+
+  let net = null;
+  if (window.Network) {
+    net = new Network(msg => {
+      if (msg.type === 'state') {
+        Object.assign(state.p2, { x: msg.x, y: msg.y, selected: msg.selected });
+        if (!state.p2Active) enableP2();
+      } else if (msg.type === 'action') {
+        playerAction(state.p2, 'P2');
+      } else if (msg.type === 'cycle') {
+        state.p2.selected = state.p2.selected === 'candy' ? 'carrot' : 'candy';
+      }
+    });
+  }
 
   function log(msg) {
     const d = document.createElement('div');
@@ -199,8 +218,15 @@
 
   // ---------- INPUT ----------
   const keys = new Set();
-  window.addEventListener('keydown', e=>{ keys.add(e.code); if (["ArrowUp","ArrowDown","ArrowLeft","ArrowRight","Space"].includes(e.code)) e.preventDefault(); });
-  window.addEventListener('keyup', e=>{ keys.delete(e.code); });
+  window.addEventListener('keydown', e=>{
+    keys.add(e.code);
+    if (net) net.handleKey(e.code, true);
+    if (["ArrowUp","ArrowDown","ArrowLeft","ArrowRight","Space"].includes(e.code)) e.preventDefault();
+  });
+  window.addEventListener('keyup', e=>{
+    keys.delete(e.code);
+    if (net) net.handleKey(e.code, false);
+  });
 
   // Touch controls
   const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
@@ -586,6 +612,10 @@
     }
     movePlayer(state.p1, 'KeyW','KeyA','KeyS','KeyD');
     if (state.p2Active) movePlayer(state.p2, 'ArrowUp','ArrowLeft','ArrowDown','ArrowRight');
+
+    if (net && net.isOpen) {
+      net.sendState({ x: state.p1.x, y: state.p1.y, selected: state.p1.selected });
+    }
 
     if (justPressed('KeyE')) playerAction(state.p1, 'P1');
     if (state.p2Active && justPressed('Slash')) playerAction(state.p2, 'P2');

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
   </footer>
 </div>
 
+<script src="network.js"></script>
 <script src="game.js"></script>
 </body>
 </html>

--- a/network.js
+++ b/network.js
@@ -1,0 +1,50 @@
+class Network {
+  constructor(onMessage) {
+    this.onMessage = onMessage;
+    this.isOpen = false;
+    try {
+      const host = window.location.hostname || 'localhost';
+      this.ws = new WebSocket(`ws://${host}:8080`);
+      this.ws.addEventListener('open', () => {
+        this.isOpen = true;
+        console.log('Connected to network server');
+      });
+      this.ws.addEventListener('message', ev => {
+        try {
+          const data = JSON.parse(ev.data);
+          if (this.onMessage) this.onMessage(data);
+        } catch (err) {
+          console.warn('Bad network message', err);
+        }
+      });
+      this.ws.addEventListener('close', () => {
+        this.isOpen = false;
+        console.log('Disconnected from network server');
+      });
+    } catch (err) {
+      console.warn('WebSocket unsupported', err);
+    }
+  }
+
+  send(msg) {
+    if (this.ws && this.isOpen) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  sendState(state) {
+    this.send({ type: 'state', ...state });
+  }
+
+  handleKey(code, down) {
+    if (!down) return;
+    if (code === 'KeyE' || code === 'Slash') this.send({ type: 'action' });
+    if (code === 'KeyQ' || code === 'Period') this.send({ type: 'cycle' });
+  }
+
+  disconnect() {
+    if (this.ws) this.ws.close();
+  }
+}
+
+window.Network = Network;

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const WebSocket = require('ws');
+
+const wss = new WebSocket.Server({ port: 8080 });
+const clients = new Set();
+
+wss.on('connection', ws => {
+  clients.add(ws);
+  ws.on('message', msg => {
+    for (const c of clients) {
+      if (c !== ws && c.readyState === WebSocket.OPEN) {
+        c.send(msg);
+      }
+    }
+  });
+  ws.on('close', () => clients.delete(ws));
+});
+
+console.log('Network server running on ws://localhost:8080');


### PR DESCRIPTION
## Summary
- Add simple WebSocket server and client to sync a second player over the local network
- Wire game logic to enable remote player automatically and fall back to local co-op when requested
- Expose network script in HTML so clients can connect on load

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bdf607fdac8323a2a4c6a2d650598f