### PR TITLE
feat: auto-hide virtual controls after keyboard use

### DIFF
--- a/game.js
+++ b/game.js
@@ -148,6 +148,8 @@
   const shopPanel = document.getElementById('shopPanel');
   const sellPanel = document.getElementById('sellPanel');
   const seedListEl = document.getElementById('seedList');
+  const p1Controls = document.getElementById('p1Controls');
+  const p2Controls = document.getElementById('p2Controls');
 
   // Basic debug logging so we can inspect whether key elements were found
   console.log('DOM elements loaded', {
@@ -159,6 +161,31 @@
     sellPanel,
     seedListEl,
   });
+
+  const isTouch = ('ontouchstart' in window) || navigator.maxTouchPoints > 0;
+
+  function bindTouchControls(container) {
+    container.querySelectorAll('button').forEach(btn => {
+      const code = btn.dataset.key;
+      const start = e => { e.preventDefault(); keys.add(code); };
+      const end = () => { keys.delete(code); };
+      btn.addEventListener('touchstart', start);
+      btn.addEventListener('touchend', end);
+      btn.addEventListener('touchcancel', end);
+      btn.addEventListener('mousedown', start);
+      btn.addEventListener('mouseup', end);
+      btn.addEventListener('mouseleave', end);
+    });
+  }
+
+  bindTouchControls(p1Controls);
+  bindTouchControls(p2Controls);
+
+  // Hide virtual controls if a keyboard is used
+  window.addEventListener('keydown', () => {
+    p1Controls.style.display = 'none';
+    p2Controls.style.display = 'none';
+  }, { once: true });
 
   addP2Btn.onclick = () => {
     state.p2Active = true;
@@ -234,7 +261,6 @@
   window.addEventListener('keyup', e=>{ keys.delete(e.code); });
 
   // Touch controls
-  const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
   console.log('Touch support detected:', isTouch);
   if (isTouch) {
     console.log('Touch mode enabled – pointer interactions will trigger player actions');

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Garden Duo — 2D Co‑op Browser Game</title>
   <style>
-    html, body { height: 100%; margin: 0; background:#dfeee3; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+    html, body { height: 100%; margin: 0; overflow:hidden; background:#dfeee3; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
     #wrap { display:flex; flex-direction:column; height:100%; }
     header { background:#20303c; color:#fff; padding:8px 12px; font-weight:600; display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
     header .pill { background:#2f4656; padding:4px 8px; border-radius:999px; font-weight:600; }
@@ -41,7 +41,8 @@
     footer code { background:#0f1b23; color:#b3e6ff; padding:2px 6px; border-radius:6px; }
 
     /* Touch controls */
-    .touch-controls { position:absolute; bottom:10px; display:none; gap:12px; }
+    .touch-controls { position:absolute; bottom:10px; display:flex; gap:12px; }
+    .touch-controls button { touch-action:none; user-select:none; }
     #p1Controls { left:10px; flex-direction:row; }
     #p2Controls { right:10px; flex-direction:row-reverse; }
     .dpad { position:relative; width:100px; height:100px; }


### PR DESCRIPTION
## Summary
- show on-screen touch controls by default
- hide virtual controls after first keyboard input
- streamline touch detection to avoid redeclaration

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/GardenHarvster/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68be3c0dcc1c8323acd647148da322ed