### PR TITLE
Load sprite atlas from root textures.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The repository includes a GitHub Actions workflow that publishes the contents of
 
 ## Texture Atlas
 
-The game loads graphics from a sprite atlas placed at `assets/atlas.png` (not included in this repository). The atlas is arranged in a 24 × 16 grid. Sprite names and their `[column, row]` positions are defined in `assets/sprites.json`. Add more entries to that file to map additional textures and use them in the game via `drawSprite(ctx, name, x, y, w, h)`.
+The game loads graphics from a sprite atlas placed at `textures.png` in the project root (not included in this repository). The atlas is arranged in a 24 × 16 grid. Sprite names and their `[column, row]` positions are defined in `assets/sprites.json`. Add more entries to that file to map additional textures and use them in the game via `drawSprite(ctx, name, x, y, w, h)`.

--- a/sprites.js
+++ b/sprites.js
@@ -1,7 +1,7 @@
 const ATLAS_COLS = 24;
 const ATLAS_ROWS = 16;
 const atlas = new Image();
-atlas.src = 'assets/atlas.png';
+atlas.src = 'textures.png';
 
 let cellW = 0;
 let cellH = 0;


### PR DESCRIPTION
## Summary
- Point sprite loader to `textures.png` in the repository root
- Document new atlas location in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a46331b08323b8af8be2eb6e59c1