### PR TITLE
Adjust seed bubble placement

### DIFF
--- a/game.js
+++ b/game.js
@@ -816,11 +816,24 @@
     ctx.fillText('🌾', p.x + p.w - 6, p.y + p.h + 2);
 
     // Selected seed bubble
+    const bubbleWidth = p.w + 8;
+    const bubbleHeight = Math.round(p.h * 0.6);
+    const bubbleX = p.x - 4;
+    const bubbleY = p.y - bubbleHeight - 12;
     ctx.fillStyle = '#0007';
-    ctx.fillRect(p.x - 2, p.y - 20, p.w + 4, 16);
+    ctx.fillRect(bubbleX, bubbleY, bubbleWidth, bubbleHeight);
+
+    const prevFont = ctx.font;
+    const prevAlign = ctx.textAlign;
+    const prevBaseline = ctx.textBaseline;
     ctx.fillStyle = '#fff';
-    ctx.font = '12px sans-serif';
-    ctx.fillText(seedEmoji(p.selected), p.x + p.w / 2 - 5, p.y - 8);
+    ctx.font = `${Math.round(r * 2)}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(seedEmoji(p.selected), bubbleX + bubbleWidth / 2, bubbleY + bubbleHeight / 2);
+    ctx.font = prevFont;
+    ctx.textAlign = prevAlign;
+    ctx.textBaseline = prevBaseline;
   }
 
   function drawPet(p) {


### PR DESCRIPTION
## Summary
- reposition the selected seed indicator bubble higher above the player and enlarge it for better visibility
- scale the selected seed emoji to match the character head size while preserving canvas text settings

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9e69f24708323a955fc5b7e0088b7