### PR TITLE
Display pet perk details in HUD

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,11 +7,16 @@
   const REPAIR_COST = 10; // cents
   // PETS (one active perk per player)
   const PETS = [
-    { id:'bee',    name:'Honey Bee',  emoji:'🐝', priceMult:1.10 },
-    { id:'bunny',  name:'Bunny',      emoji:'🐰', speed:+0.4 },
-    { id:'sprout', name:'Sprout',     emoji:'🌱', plantGrowth:1.10 },
-    { id:'robot',  name:'Robot',      emoji:'🤖', randomMutation:true },
+    { id:'bee',    name:'Honey Bee',  emoji:'🐝', priceMult:1.10, perk:'Sell price +10%' },
+    { id:'bunny',  name:'Bunny',      emoji:'🐰', speed:+0.4,      perk:'Movement speed boost' },
+    { id:'sprout', name:'Sprout',     emoji:'🌱', plantGrowth:1.10, perk:'Plants grow 10% faster' },
+    { id:'robot',  name:'Robot',      emoji:'🤖', randomMutation:true, perk:'Chance for random crop mutations' },
   ];
+
+  function describePet(petDef) {
+    if (!petDef) return '—';
+    return petDef.perk ? `${petDef.name} (${petDef.perk})` : petDef.name;
+  }
 
   const SEED_CATALOG = [
     { id:'candy', name:'Candy Blossom', harvest:'Multiple', sheckles:2, robux:0 },
@@ -782,7 +787,7 @@
       const pet = pool[Math.floor(Math.random()*pool.length)];
       p.pets.push({id:pet.id});
       p.pet = {id:pet.id, x:p.x-16, y:p.y-16};
-      log(`${who} received a pet: ${pet.name}! Perk applied.`);
+      log(`${who} received a pet: ${describePet(pet)}.`);
     } else {
       p.money += 100; log(`${who} already has all pets. Awarded ¢100 instead.`);
     }
@@ -851,7 +856,7 @@
     // HUD
     p1moneyEl.textContent = `P1 Money: ¢${state.p1.money}`;
     const matchPet1 = state.p1.pet ? PETS.find(p=>p.id===state.p1.pet.id) : null;
-    const petName1 = matchPet1 ? matchPet1.name : '—';
+    const petName1 = describePet(matchPet1);
     const invEntries1 = Object.entries(state.p1.invSeeds).filter(([k,v])=>v>0);
     const inv1 = invEntries1.map(([k,v],i)=>`${i+1}:${k}(${v})`).join(', ') || '—';
     const bag1 = Object.entries(state.p1.bag).filter(([k,v])=>v>0).map(([k,v])=>`${k}:${v}`).join(', ') || '—';
@@ -860,7 +865,7 @@
     if (state.p2Active) {
       p2moneyEl.textContent = `P2 Money: ¢${state.p2.money}`;
       const matchPet2 = state.p2.pet ? PETS.find(p=>p.id===state.p2.pet.id) : null;
-      const petName2 = matchPet2 ? matchPet2.name : '—';
+      const petName2 = describePet(matchPet2);
       const invEntries2 = Object.entries(state.p2.invSeeds).filter(([k,v])=>v>0);
       const inv2 = invEntries2.map(([k,v],i)=>`${i+1}:${k}(${v})`).join(', ') || '—';
       const bag2 = Object.entries(state.p2.bag).filter(([k,v])=>v>0).map(([k,v])=>`${k}:${v}`).join(', ') || '—';


### PR DESCRIPTION
## Summary
- add descriptive perk strings to each pet definition
- show each player's active pet perk in the header HUD and award log message

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9ec9a15308323bee12d93a9d5dc5e