### PR TITLE
Revise embed to open in overlay

### DIFF
--- a/azuracast-embed.js
+++ b/azuracast-embed.js
@@ -1,7 +1,9 @@
 (function attachGardenHarvsterEmbed() {
   const GAME_URL = 'https://openclutch.github.io/GardenHarvster/';
-  const SECTION_ID = 'garden-harvster-embed';
+  const OVERLAY_ID = 'garden-harvster-overlay';
+  const TOGGLE_ID = 'garden-harvster-toggle';
   const STYLE_ID = 'garden-harvster-embed-style';
+  const NO_SCROLL_CLASS = 'garden-harvster-overlay-open';
 
   const injectStyles = () => {
     if (document.getElementById(STYLE_ID)) {
@@ -11,75 +13,113 @@
     const style = document.createElement('style');
     style.id = STYLE_ID;
     style.textContent = `
-      #${SECTION_ID} {
-        margin: 2rem auto;
-        max-width: 960px;
-        background: rgba(255, 255, 255, 0.92);
-        border-radius: 12px;
-        box-shadow: 0 18px 40px -24px rgba(18, 26, 33, 0.8);
-        padding: 1.75rem;
-        color: #102029;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        backdrop-filter: blur(6px);
-      }
-
-      #${SECTION_ID} h2 {
-        margin: 0 0 0.5rem;
-        font-size: 1.6rem;
-        color: #1f3b4d;
-      }
-
-      #${SECTION_ID} p {
-        margin: 0 0 1rem;
-        line-height: 1.45;
-        color: #1b2a33;
-      }
-
-      #${SECTION_ID} .embed-frame {
-        position: relative;
-        border-radius: 10px;
+      body.${NO_SCROLL_CLASS} {
         overflow: hidden;
-        border: 2px solid rgba(18, 26, 33, 0.15);
-        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
       }
 
-      #${SECTION_ID} iframe {
-        display: block;
-        width: 100%;
-        min-height: clamp(420px, 60vh, 640px);
-        border: 0;
-        background: #dfeee3;
-      }
-
-      #${SECTION_ID} a.launch-link {
+      #${TOGGLE_ID} {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        z-index: 2147483642;
+        border: none;
+        background: #1f3b4d;
+        color: #f4fbff;
+        padding: 0.65rem 1.2rem;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.95rem;
+        box-shadow: 0 18px 36px -20px rgba(12, 26, 38, 0.9);
+        cursor: pointer;
         display: inline-flex;
         align-items: center;
         gap: 0.4rem;
-        margin-top: 0.75rem;
-        padding: 0.55rem 1.1rem;
-        border-radius: 999px;
-        font-weight: 600;
-        text-decoration: none;
-        background: #1f3b4d;
-        color: #f4fbff;
-        transition: transform 0.12s ease, box-shadow 0.12s ease;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
       }
 
-      #${SECTION_ID} a.launch-link:hover,
-      #${SECTION_ID} a.launch-link:focus-visible {
+      #${TOGGLE_ID}:hover,
+      #${TOGGLE_ID}:focus-visible {
         transform: translateY(-1px);
-        box-shadow: 0 10px 24px -12px rgba(16, 32, 45, 0.7);
+        box-shadow: 0 24px 40px -18px rgba(12, 26, 38, 0.95);
         outline: none;
       }
 
-      @media (max-width: 720px) {
-        #${SECTION_ID} {
-          margin: 1.25rem;
-          padding: 1.25rem;
+      #${TOGGLE_ID}:focus-visible {
+        box-shadow: 0 0 0 3px rgba(31, 59, 77, 0.35);
+      }
+
+      #${OVERLAY_ID} {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(16px, 5vw, 48px);
+        background: rgba(6, 18, 26, 0.82);
+        backdrop-filter: blur(6px);
+        z-index: 2147483641;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.16s ease;
+      }
+
+      #${OVERLAY_ID}.open {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      #${OVERLAY_ID} .embed-shell {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.65rem;
+        width: min(92vw, 960px);
+      }
+
+      #${OVERLAY_ID} iframe {
+        width: 100%;
+        height: clamp(360px, 70vh, 640px);
+        border: 0;
+        border-radius: 14px;
+        background: #dfeee3;
+        box-shadow: 0 20px 42px -24px rgba(0, 0, 0, 0.8);
+      }
+
+      #${OVERLAY_ID} .launch-link {
+        align-self: flex-end;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        background: rgba(15, 31, 43, 0.92);
+        color: #e9f6ff;
+        text-decoration: none;
+        font-size: 0.82rem;
+        font-weight: 600;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      #${OVERLAY_ID} .launch-link:hover,
+      #${OVERLAY_ID} .launch-link:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 22px -14px rgba(0, 0, 0, 0.8);
+        outline: none;
+      }
+
+      @media (max-width: 520px) {
+        #${TOGGLE_ID} {
+          bottom: 16px;
+          right: 16px;
+          padding: 0.55rem 1rem;
+          font-size: 0.9rem;
         }
 
-        #${SECTION_ID} iframe {
-          min-height: clamp(360px, 55vh, 520px);
+        #${OVERLAY_ID} .embed-shell {
+          width: min(96vw, 520px);
+          gap: 0.5rem;
+        }
+
+        #${OVERLAY_ID} iframe {
+          height: clamp(240px, 65vh, 520px);
+          border-radius: 12px;
         }
       }
     `;
@@ -87,33 +127,41 @@
     document.head.appendChild(style);
   };
 
-  const renderEmbed = () => {
-    if (document.getElementById(SECTION_ID)) {
+  const setOverlayVisible = (visible) => {
+    const overlay = document.getElementById(OVERLAY_ID);
+    const toggle = document.getElementById(TOGGLE_ID);
+
+    if (!overlay || !toggle) {
       return;
     }
 
-    const host =
-      document.querySelector('[data-role="content"]') ||
-      document.querySelector('main') ||
-      document.querySelector('#app') ||
-      document.body;
+    overlay.classList.toggle('open', visible);
+    overlay.setAttribute('aria-hidden', String(!visible));
+    toggle.setAttribute('aria-expanded', String(visible));
 
-    if (!host) {
+    if (visible) {
+      document.body.classList.add(NO_SCROLL_CLASS);
+      toggle.style.display = 'none';
+    } else {
+      document.body.classList.remove(NO_SCROLL_CLASS);
+      toggle.style.display = '';
+      toggle.focus({ preventScroll: true });
+    }
+  };
+
+  const ensureOverlay = () => {
+    if (document.getElementById(OVERLAY_ID)) {
       return;
     }
 
-    const section = document.createElement('section');
-    section.id = SECTION_ID;
+    const overlay = document.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-hidden', 'true');
 
-    const heading = document.createElement('h2');
-    heading.textContent = 'Play Garden Harvster';
-
-    const description = document.createElement('p');
-    description.innerHTML =
-      'Take a co-op farming break with <strong>Garden Harvster</strong>, a 2-player browser game that runs right in your station\'s public page.';
-
-    const frameWrapper = document.createElement('div');
-    frameWrapper.className = 'embed-frame';
+    const shell = document.createElement('div');
+    shell.className = 'embed-shell';
 
     const iframe = document.createElement('iframe');
     iframe.src = GAME_URL;
@@ -126,20 +174,54 @@
     link.href = GAME_URL;
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
-    link.textContent = 'Open Garden Harvster in a new tab';
+    link.textContent = 'Open in browser';
 
-    frameWrapper.appendChild(iframe);
-    section.appendChild(heading);
-    section.appendChild(description);
-    section.appendChild(frameWrapper);
-    section.appendChild(link);
+    shell.appendChild(iframe);
+    shell.appendChild(link);
+    overlay.appendChild(shell);
 
-    host.appendChild(section);
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        setOverlayVisible(false);
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        const isOpen = overlay.classList.contains('open');
+        if (isOpen) {
+          event.preventDefault();
+          setOverlayVisible(false);
+        }
+      }
+    });
+
+    document.body.appendChild(overlay);
+  };
+
+  const ensureToggleButton = () => {
+    if (document.getElementById(TOGGLE_ID)) {
+      return;
+    }
+
+    const toggle = document.createElement('button');
+    toggle.id = TOGGLE_ID;
+    toggle.type = 'button';
+    toggle.textContent = 'Play Garden Harvster';
+    toggle.setAttribute('aria-controls', OVERLAY_ID);
+    toggle.setAttribute('aria-expanded', 'false');
+
+    toggle.addEventListener('click', () => {
+      setOverlayVisible(true);
+    });
+
+    document.body.appendChild(toggle);
   };
 
   const init = () => {
     injectStyles();
-    renderEmbed();
+    ensureOverlay();
+    ensureToggleButton();
   };
 
   if (document.readyState === 'complete' || document.readyState === 'interactive') {


### PR DESCRIPTION
## Summary
- replace the inline embed section with a bottom-right "Play Garden Harvster" toggle button
- display the game inside a modal overlay with only the iframe and a small "Open in browser" link
- remove the previous descriptive text and lock page scrolling while the overlay is open

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca089cd3b0832398d0732a1620963c