### PR TITLE
Refine header styling for a slimmer top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,14 @@
   <style>
     html, body { height: 100%; margin: 0; overflow:hidden; background:#dfeee3; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
     #wrap { display:flex; flex-direction:column; height:100%; }
-    header { background:#20303c; color:#fff; padding:8px 12px; font-weight:600; display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
-    header .status-group { display:flex; flex-wrap:wrap; gap:8px; }
-    header .pill { background:#2f4656; padding:4px 8px; border-radius:999px; font-weight:600; }
-    header .hint { opacity:.85; font-weight:500; flex-basis:100%; font-size:14px; }
-    header button { border:1px solid #1a2730; background:#2f4656; color:#e8f6ff; border-radius:999px; padding:4px 10px; cursor:pointer; }
-    header .actions { display:flex; gap:8px; align-items:center; margin-left:auto; flex-wrap:wrap; }
-    header .savebar { display:flex; gap:8px; align-items:center; }
+    header { background:#1b2731; color:#f4fbff; padding:6px 16px; font-weight:600; display:flex; align-items:center; gap:10px; flex-wrap:wrap; box-shadow:0 1px 0 #152029 inset; }
+    header .status-group { display:flex; flex-wrap:wrap; gap:6px; row-gap:4px; }
+    header .pill { background:#253745; padding:3px 10px; border-radius:999px; font-weight:600; font-size:14px; letter-spacing:.01em; }
+    header .hint { opacity:.8; font-weight:500; flex-basis:100%; font-size:13px; }
+    header button { border:1px solid #19242d; background:#253745; color:#eaf5ff; border-radius:999px; padding:3px 12px; cursor:pointer; font-weight:600; }
+    header button:hover { background:#2e4557; }
+    header .actions { display:flex; gap:6px; align-items:center; margin-left:auto; flex-wrap:wrap; }
+    header .savebar { display:flex; gap:6px; align-items:center; }
     header .savebar input[type=file]{ display:none; }
     .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 


### PR DESCRIPTION
## Summary
- tighten the header padding, gaps, and pill styling to reduce visual bulk
- refresh header colors and add a hover state for buttons to keep a clean appearance
- slim down the save bar spacing to align with the trimmer layout

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb695324a88323a75ee35575ff9102